### PR TITLE
Fixes code highlighting

### DIFF
--- a/src/computed-properties.md
+++ b/src/computed-properties.md
@@ -31,7 +31,7 @@ describe("NumberRenderer", () => {
 
 Before running the test, let's set up `<NumberRenderer>`:
 
-```
+```js
 <template>
   <div>
   </div>


### PR DESCRIPTION
Currently it looks like so: https://lmiller1990.github.io/vue-testing-handbook/computed-properties.html#testing-by-rendering-the-value