### PR TITLE
fix typo about the mountWrapper and shallowWrapper

### DIFF
--- a/src/rendering-a-component.md
+++ b/src/rendering-a-component.md
@@ -50,7 +50,7 @@ console.log(mountWrapper.html())
 <div><div>Child component</div></div>
 ```
 
-Which is the completely rendered markup of `Parent` and `Child`. `mountWrapper.html()`, on the other hand, produces this:
+Which is the completely rendered markup of `Parent` and `Child`. `shallowWrapper.html()`, on the other hand, produces this:
 
 ```html
 <div><vuecomponent-stub></vuecomponent-stub></div>


### PR DESCRIPTION
It used two times the same reference for different variables names