### PR TITLE
Fixes various typos in 'Setting Up for TDD'

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@ Welcome to the Vue Testing Handbook!
 
 ## What is this?
 
-This is a collection of short, focused examples on how to test Vue components. It uses `vue-test-utils`, the official library for testing Vue components, and Jest, a modern testing framework. It covers the `vue-test-utils` API, as well as best practises and useful parts of the Jest API for testing Vue components, as well an a demo project with all the example code.
+This is a collection of short, focused examples on how to test Vue components. It uses `vue-test-utils`, the official library for testing Vue components, and Jest, a modern testing framework. It covers the `vue-test-utils` API, as well as best practises and useful parts of the Jest API for testing Vue components, as well as a demo project with all the example code.
 
 ## Style
 
 Most sections have have a simple component or two, some tests, and the related code. Here is an example
 
 - [Setting up for TDD](https://github.com/lmiller1990/vue-testing-handbook/blob/master/docs/setting-up-for-tdd.md). This is a guide about setting up an environment for TDD.
-- [Component](https://github.com/lmiller1990/vue-testing-handbook/blob/master/demo-app/src/components/Greeting.vue). This is the component usd in the guide.
+- [Component](https://github.com/lmiller1990/vue-testing-handbook/blob/master/demo-app/src/components/Greeting.vue). This is the component used in the guide.
 - [Test](https://github.com/lmiller1990/vue-testing-handbook/blob/master/demo-app/tests/unit/Greeting.spec.js). This is the test used in the guide.
 
 Guides should be short, concise, and focused on a single concept. The relevant code should be linked in the article, and easily reproduced by the reader.
@@ -36,9 +36,11 @@ Clone the repo and run `yarn` to install the dependencies. Then run `yarn dev` t
 
 There is an example project to run tests and examples used in the guides. To run it the demo app, run `cd demo-app` to navigate into the project, then run `yarn` to install the dependencies. Run `yarn test:unit` to execute the test suite.
 
-### Updates existing guides
+### Updates to existing guides
 
 Make an issue regarding what you think can be improved, or just make a PR. 
+
+Source files for guides can be found in the `src` folder, written in Markdown (ending with `.md`). For example, to propose a change in the [Setting up for TDD](https://github.com/lmiller1990/vue-testing-handbook/blob/master/docs/setting-up-for-tdd.md) guide, you will need to edit `src/setting-up-for-tdd.md`.
 
 ### Adding a new page
 

--- a/src/setting-up-for-tdd.md
+++ b/src/setting-up-for-tdd.md
@@ -81,9 +81,9 @@ describe('Greeting.vue', () => {
 })
 ```
 
-There are different syntaxes used for TDD, we will use the commonly seen `describe` and `it` syntax that comes with Jest. `describe` generally outlines what the test is about, in this case `Greeting.vue`. `it` represents a single piece of responsibility that the subject of the test should fullfil. As we add more features to the component, we add more `it` blocks.
+There are different syntaxes used for TDD, we will use the commonly seen `describe` and `it` syntax that comes with Jest. `describe` generally outlines what the test is about, in this case `Greeting.vue`. `it` represents a single piece of responsibility that the subject of the test should fulfill. As we add more features to the component, we add more `it` blocks.
 
-Now we should render the component with `mount`. The standard practice it to assign the component to a variable called `wrapper`. We will also print the output, to make sure everything is running correctly:
+Now we should render the component with `mount`. The standard practice is to assign the component to a variable called `wrapper`. We will also print the output, to make sure everything is running correctly:
 
 ```js
 const wrapper = mount(Greeting)
@@ -105,8 +105,9 @@ console.log tests/unit/Greeting.spec.js:7
     Vue and TDD
   </div>
 ```
-
-We can see the markup is correct, and the test passes. The test is passing because there was no failure - this test can never fail, so it is very useful yet. Even if we change `Greeting.vue` and delete the `{{ message }}`, it will still pass. Let's change that.
+:::v-pre
+We can see the markup is correct, and the test passes. The test is passing because there was no failure - this test can never fail, so it is not very useful yet. Even if we change `Greeting.vue` and delete the `{{ greeting }}`, it will still pass. Let's change that.
+:::
 
 ## Making assertions
 
@@ -118,7 +119,7 @@ _Matchers_ are methods to compare values and objects. For example:
 expect(1).toBe(1)
 ```
 
-A full list of matchers available in the [Jest documentation](http://jestjs.io/docs/en/expect). `vue-test-utils` doesn't include any matchers - the ones Jest provides are more than enough. We want to compare the text from `Greeting`. We could write:
+A full list of matchers is available in the [Jest documentation](http://jestjs.io/docs/en/expect). `vue-test-utils` doesn't include any matchers - the ones Jest provides are more than enough. We want to compare the text from `Greeting`. We could write:
 
 ```js
 expect(wrapper.html().includes("Vue and TDD").toBe(true)
@@ -152,7 +153,7 @@ Snapshots:   0 total
 Time:        1.477s, estimated 2s
 ```
 
-Looking good. But you should always see a test fail, then pass, to make sure it's really working. In traditional TDD, you would write the test before the actual implementation, see if fail, the use the failing errors to guide your code. Let's make sure this test is really working. Update `Greeting.vue`:
+Looking good. But you should always see a test fail, then pass, to make sure it's really working. In traditional TDD, you would write the test before the actual implementation, see it fail, then use the failing errors to guide your code. Let's make sure this test is really working. Update `Greeting.vue`:
 
 ```vue
 <template>
@@ -203,4 +204,4 @@ Greeting.vue
 
 Jest gives us good feedback. We can see the expected and actual result, as well as on which line the expectation failed. The test did fail, as expected. Revert `Greeting.vue` and make sure the test is passing again.
 
-Next we will look at the two methods `vue-test-utils` provides to render components - `mount` and `shallowMount`. 
+Next we will look at the two methods `vue-test-utils` provides to render components: `mount` and `shallowMount`. 

--- a/src/setting-up-for-tdd.md
+++ b/src/setting-up-for-tdd.md
@@ -105,9 +105,8 @@ console.log tests/unit/Greeting.spec.js:7
     Vue and TDD
   </div>
 ```
-:::v-pre
-We can see the markup is correct, and the test passes. The test is passing because there was no failure - this test can never fail, so it is not very useful yet. Even if we change `Greeting.vue` and delete the `{{ greeting }}`, it will still pass. Let's change that.
-:::
+
+We can see the markup is correct, and the test passes. The test is passing because there was no failure - this test can never fail, so it is not very useful yet. Even if we change `Greeting.vue` and delete the `greeting` from the template, it will still pass. Let's change that.
 
 ## Making assertions
 


### PR DESCRIPTION
Also added `:::v-pre` for the paragraph in "Running the test" as it contained a Vue-style interpolation `{{ greeting }}` which was being compiled by Vuepress and showing up empty.