### PR TITLE
Fix js in markdown

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,8 +6,8 @@
     "jest": true,
     "afterEach": true
   },
-  env: {
-    node: true
+  "env": {
+    "node": true
   },
   "parserOptions": {
     "parser": "babel-eslint",
@@ -22,9 +22,22 @@
     "indent": ["error", 2],
     "no-multi-spaces": "error"
   },
-   extends: [
-    'eslint:recommended',
-    'plugin:vue/base',
-    'plugin:vue/essential'
+  "extends": [
+    "eslint:recommended",
+    "plugin:vue/base",
+    "plugin:vue/essential"
+  ],
+  "overrides": [
+    {
+      "files": "*.md",
+      "plugins": [
+        "markdown"
+      ],
+      "rules": {
+        "no-unused-vars": "off",
+        "no-console": "off",
+        "no-undef": "off"
+      }
+    }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "dev": "vuepress dev src",
     "docs:build": "vuepress build src",
+    "docs:lint": "yarn eslint --ext md .",
     "lint": "yarn eslint --ext js,vue ."
   },
   "dependencies": {
@@ -14,6 +15,7 @@
   "devDependencies": {
     "babel-eslint": "^8.2.6",
     "eslint": "^5.1.0",
+    "eslint-plugin-markdown": "^1.0.0-beta.6",
     "eslint-plugin-vue": "^4.5.0",
     "markdown-it-include": "^1.0.0"
   }

--- a/src/computed-properties.md
+++ b/src/computed-properties.md
@@ -31,7 +31,7 @@ describe("NumberRenderer", () => {
 
 Before running the test, let's set up `<NumberRenderer>`:
 
-```js
+```vue
 <template>
   <div>
   </div>
@@ -65,17 +65,19 @@ Now we start development, and let the error messages guide our implementation. `
 It looks like everything is hooked up correctly. Let's start implementing `numbers`:
 
 ```js
-computed: {
-  numbers() {
-    const evens = []
+export default {
+  computed: {
+    numbers() {
+      const evens = []
 
-    for (let i = 1; i < 10; i++) {
-      if (i % 2 === 0) {
-        evens.push(i)
+      for (let i = 1; i < 10; i++) {
+        if (i % 2 === 0) {
+          evens.push(i)
+        }
       }
-    }
 
-    return evens
+      return evens
+    }
   }
 }
 ```
@@ -147,19 +149,23 @@ Update `numbers`:
 
 
 ```js
-numbers() {
-  const evens = []
-  const odds = []
+export default {
+  computed: {
+    numbers() {
+      const evens = []
+      const odds = []
 
-  for (let i = 1; i < 10; i++) {
-    if (i % 2 === 0) {
-      evens.push(i)
-    } else {
-      odds.push(i)
+      for (let i = 1; i < 10; i++) {
+        if (i % 2 === 0) {
+          evens.push(i)
+        } else {
+          odds.push(i)
+        }
+      }
+
+      return this.even === true ? evens.join(", ") : odds.join(", ")
     }
   }
-
-  return this.even === true ? evens.join(", ") : odds.join(", ")
 }
 ```
 

--- a/src/finding-elements-and-components.md
+++ b/src/finding-elements-and-components.md
@@ -126,7 +126,7 @@ It passes! Using the `name` property can be a little unintuitive, so importing t
 
 There is often cases when you want to assert a number of elements is rendered. A common case is a list of items rendered with `v-for`. Here is a `<ParentWithManyChildren>` that renders several `<Child>` components.
 
-```js
+```vue
 <template>
   <div>
     <Child v-for="id in [1, 2 ,3]" :key="id" />

--- a/src/ja/computed-properties.md
+++ b/src/ja/computed-properties.md
@@ -65,17 +65,19 @@ export default {
 `numbers`の算出プロパティを書いてみます。
 
 ```js
-computed: {
-  numbers() {
-    const evens = []
+export default {
+  computed: {
+    numbers() {
+      const evens = []
 
-    for (let i = 1; i < 10; i++) {
-      if (i % 2 === 0) {
-        evens.push(i)
+      for (let i = 1; i < 10; i++) {
+        if (i % 2 === 0) {
+          evens.push(i)
+        }
       }
-    }
 
-    return evens
+      return evens
+    }
   }
 }
 ```
@@ -146,19 +148,23 @@ FAIL  tests/unit/NumberRenderer.spec.js
 `numbers`を更新します：
 
 ```js
-numbers() {
-  const evens = []
-  const odds = []
+export default {
+  computed: {
+    numbers() {
+      const evens = []
+      const odds = []
 
-  for (let i = 1; i < 10; i++) {
-    if (i % 2 === 0) {
-      evens.push(i)
-    } else {
-      odds.push(i)
+      for (let i = 1; i < 10; i++) {
+        if (i % 2 === 0) {
+          evens.push(i)
+        } else {
+          odds.push(i)
+        }
+      }
+
+      return this.even === true ? evens.join(", ") : odds.join(", ")
     }
   }
-
-  return this.even === true ? evens.join(", ") : odds.join(", ")
 }
 ```
 

--- a/src/ja/simulating-user-input.md
+++ b/src/ja/simulating-user-input.md
@@ -99,14 +99,18 @@ describe("FormSubmitter", () => {
 エイリアスして、`this.$http`でフォームを送信する実装はこうです。
 
 ```js
-handleSubmitAsync() {
-  return this.$http.get("/api/v1/register", { username: this.username })
-    .then(() => {
-      // メッセージを表示するなど
-    })
-    .catch(() => {
-      // エラーをハンドル
-    })
+export default {
+  methods: {
+    handleSubmitAsync() {
+      return this.$http.get("/api/v1/register", { username: this.username })
+        .then(() => {
+          // メッセージを表示するなど
+        })
+        .catch(() => {
+          // エラーをハンドル
+        })
+    }
+  }
 }
 ```
 
@@ -134,15 +138,17 @@ const mockHttp = {
 テストを書く前に、`handleSubmitAsync`を更新します：
 
 ```js
-methods: {
-  handleSubmitAsync() {
-    return this.$http.get("/api/v1/register", { username: this.username })
-      .then(() => {
-        this.submitted = true
-      })
-      .catch((e) => {
-        throw Error("Something went wrong", e)
-      })
+export default {
+  methods: {
+    handleSubmitAsync() {
+      return this.$http.get("/api/v1/register", { username: this.username })
+        .then(() => {
+          this.submitted = true
+        })
+        .catch((e) => {
+          throw Error("Something went wrong", e)
+        })
+    }
   }
 }
 ```

--- a/src/setting-up-for-tdd.md
+++ b/src/setting-up-for-tdd.md
@@ -70,7 +70,7 @@ export default {
 
 Create a `Greeting.spec.js` inside `tests/unit`. Inside, import `Greeting.vue`, as well as `mount`, and add the outline of the test:
 
-```
+```js
 import { mount } from '@vue/test-utils'
 import Greeting from '@/components/Greeting.vue'
 
@@ -86,6 +86,7 @@ There are different syntaxes used for TDD, we will use the commonly seen `descri
 Now we should render the component with `mount`. The standard practice is to assign the component to a variable called `wrapper`. We will also print the output, to make sure everything is running correctly:
 
 ```js
+import Greeting from '@/components/Greeting.vue'
 const wrapper = mount(Greeting)
 
 console.log(wrapper.html())

--- a/src/simulating-user-input.md
+++ b/src/simulating-user-input.md
@@ -97,14 +97,18 @@ Forms are usually submitted to some endpoint. Let's see how we might test this c
 Often the http library is, `axios`, a popular HTTP client. In this case, `handleSubmit` would likely look something like this:
 
 ```js
-handleSubmitAsync() {
-  return this.$http.get("/api/v1/register", { username: this.username })
-    .then(() => {
-      // show success message, etc
-    })
-    .catch(() => {
-      // handle error
-    })
+export default {
+  methods: {
+    handleSubmitAsync() {
+      return this.$http.get("/api/v1/register", { username: this.username })
+        .then(() => {
+          // show success message, etc
+        })
+        .catch(() => {
+          // handle error
+        })
+    }
+  }
 }
 ```
 
@@ -133,15 +137,17 @@ There are a few interesting things going on here:
 Before seeing the test, here is the new `handleSubmitAsync` function:
 
 ```js
-methods: {
-  handleSubmitAsync() {
-    return this.$http.get("/api/v1/register", { username: this.username })
-      .then(() => {
-        this.submitted = true
-      })
-      .catch((e) => {
-        throw Error("Something went wrong", e)
-      })
+export default {
+  methods: {
+    handleSubmitAsync() {
+      return this.$http.get("/api/v1/register", { username: this.username })
+        .then(() => {
+          this.submitted = true
+        })
+        .catch((e) => {
+          throw Error("Something went wrong", e)
+        })
+    }
   }
 }
 ```

--- a/src/stubbing-components.md
+++ b/src/stubbing-components.md
@@ -15,8 +15,10 @@ When writing unit tests, often we want to _stub_ parts of the code we are not in
 `<UsersDisplay>` has a `created` lifecycle method like this:
 
 ```js
-created() {
-  axios.get("/users")
+export default {
+  created() {
+    axios.get("/users")
+  }
 }
 ```
 

--- a/src/vue-router.md
+++ b/src/vue-router.md
@@ -244,7 +244,7 @@ export default router
 In your unit test, you __could__ import the router instance, and attempt to call `beforeEach` by typing `router.beforeHooks[0]()`. This will throw an error about `next` - since you didn't pass the correct arguments. Instead of this, one strategy is to decouple and independently export the `beforeEach` navigation hook, before coupling it to the router. How about:
 
 ```js
-export function beforeEach((to, from, next) {
+export function beforeEach(to, from, next) {
   if (to.matched.some(record => record.meta.shouldBustCache)) {
     bustCache()
   }

--- a/src/vuex-getters.md
+++ b/src/vuex-getters.md
@@ -40,9 +40,11 @@ export default {
 Nothing too exciting - remember that getters receive other gettes as the second argument. Since we already have a `poodles` getter, we can use that in `poodlesByAge`. By returning a function in `poodlesByAge` that takes an argument, we can pass arguments to getters. The `poodlesByAge` getter can be used like this:
 
 ```js
-computed: {
-  puppies() {
-    return this.$store.getters.poodlesByAge(1)
+export default {
+  computed: {
+    puppies() {
+      return this.$store.getters.poodlesByAge(1)
+    }
   }
 }
 ```

--- a/yarn.lock
+++ b/yarn.lock
@@ -1247,6 +1247,10 @@ babylon@7.0.0-beta.47:
   version "7.0.0-beta.47"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.47.tgz#6d1fa44f0abec41ab7c780481e62fd9aafbdea80"
 
+bail@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/bail/-/bail-1.0.3.tgz#63cfb9ddbac829b02a3128cd53224be78e6c21a3"
+
 balanced-match@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-0.4.2.tgz#cb3f3e3c732dc0f01ee70b403f302e61d7709838"
@@ -1540,6 +1544,18 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.3.0, chalk@^2.3.2, chalk@^2.4
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
+character-entities-legacy@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/character-entities-legacy/-/character-entities-legacy-1.1.2.tgz#7c6defb81648498222c9855309953d05f4d63a9c"
+
+character-entities@^1.0.0:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/character-entities/-/character-entities-1.2.2.tgz#58c8f371c0774ef0ba9b2aca5f00d8f100e6e363"
+
+character-reference-invalid@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/character-reference-invalid/-/character-reference-invalid-1.1.2.tgz#21e421ad3d84055952dab4a43a04e73cd425d3ed"
+
 chardet@^0.4.0:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
@@ -1655,6 +1671,10 @@ coa@~1.0.1:
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+
+collapse-white-space@^1.0.2:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/collapse-white-space/-/collapse-white-space-1.0.4.tgz#ce05cf49e54c3277ae573036a26851ba430a0091"
 
 collection-visit@^1.0.0:
   version "1.0.0"
@@ -2382,6 +2402,14 @@ escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
 
+eslint-plugin-markdown@^1.0.0-beta.6:
+  version "1.0.0-beta.6"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-markdown/-/eslint-plugin-markdown-1.0.0-beta.6.tgz#d9e62666eea4e76387e85f502df668abdfbd4395"
+  dependencies:
+    object-assign "^4.0.1"
+    remark-parse "^3.0.0"
+    unified "^6.1.2"
+
 eslint-plugin-vue@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-vue/-/eslint-plugin-vue-4.5.0.tgz#09d6597f4849e31a3846c2c395fccf17685b69c3"
@@ -2567,6 +2595,10 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
   dependencies:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
+
+extend@^3.0.0:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
 
 external-editor@^2.1.0:
   version "2.2.0"
@@ -3206,6 +3238,17 @@ is-accessor-descriptor@^1.0.0:
   dependencies:
     kind-of "^6.0.0"
 
+is-alphabetical@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-alphabetical/-/is-alphabetical-1.0.2.tgz#1fa6e49213cb7885b75d15862fb3f3d96c884f41"
+
+is-alphanumerical@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-alphanumerical/-/is-alphanumerical-1.0.2.tgz#1138e9ae5040158dc6ff76b820acd6b7a181fd40"
+  dependencies:
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
@@ -3216,7 +3259,7 @@ is-binary-path@^1.0.0:
   dependencies:
     binary-extensions "^1.0.0"
 
-is-buffer@^1.1.5:
+is-buffer@^1.1.4, is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
 
@@ -3251,6 +3294,10 @@ is-data-descriptor@^1.0.0:
 is-date-object@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.1.tgz#9aa20eb6aeebbff77fbd33e74ca01b33581d3a16"
+
+is-decimal@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-decimal/-/is-decimal-1.0.2.tgz#894662d6a8709d307f3a276ca4339c8fa5dff0ff"
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -3331,6 +3378,10 @@ is-glob@^4.0.0:
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.0.tgz#9521c76845cc2610a85203ddf080a958c2ffabc0"
   dependencies:
     is-extglob "^2.1.1"
+
+is-hexadecimal@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-hexadecimal/-/is-hexadecimal-1.0.2.tgz#b6e710d7d07bb66b98cb8cece5c9b4921deeb835"
 
 is-installed-globally@^0.1.0:
   version "0.1.0"
@@ -3437,9 +3488,17 @@ is-symbol@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.1.tgz#3cc59f00025194b6ab2e38dbae6689256b660572"
 
+is-whitespace-character@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.2.tgz#ede53b4c6f6fb3874533751ec9280d01928d03ed"
+
 is-windows@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
+
+is-word-character@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-word-character/-/is-word-character-1.0.2.tgz#46a5dac3f2a1840898b91e576cd40d493f3ae553"
 
 is-wsl@^1.1.0:
   version "1.1.0"
@@ -3866,6 +3925,10 @@ map-visit@^1.0.0:
   resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
   dependencies:
     object-visit "^1.0.0"
+
+markdown-escapes@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/markdown-escapes/-/markdown-escapes-1.0.2.tgz#e639cbde7b99c841c0bacc8a07982873b46d2122"
 
 markdown-it-anchor@^4.0.0:
   version "4.0.0"
@@ -4520,6 +4583,17 @@ parse-asn1@^5.0.0:
     create-hash "^1.1.0"
     evp_bytestokey "^1.0.0"
     pbkdf2 "^3.0.3"
+
+parse-entities@^1.0.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.2.0.tgz#9deac087661b2e36814153cb78d7e54a4c5fd6f4"
+  dependencies:
+    character-entities "^1.0.0"
+    character-entities-legacy "^1.0.0"
+    character-reference-invalid "^1.0.0"
+    is-alphanumerical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-hexadecimal "^1.0.0"
 
 parse-glob@^3.0.4:
   version "3.0.4"
@@ -5261,6 +5335,27 @@ relateurl@0.2.x:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
 
+remark-parse@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/remark-parse/-/remark-parse-3.0.1.tgz#1b9f841a44d8f4fbf2246850265459a4eb354c80"
+  dependencies:
+    collapse-white-space "^1.0.2"
+    has "^1.0.1"
+    is-alphabetical "^1.0.0"
+    is-decimal "^1.0.0"
+    is-whitespace-character "^1.0.0"
+    is-word-character "^1.0.0"
+    markdown-escapes "^1.0.0"
+    parse-entities "^1.0.2"
+    repeat-string "^1.5.4"
+    state-toggle "^1.0.0"
+    trim "0.0.1"
+    trim-trailing-lines "^1.0.0"
+    unherit "^1.0.4"
+    unist-util-remove-position "^1.0.0"
+    vfile-location "^2.0.0"
+    xtend "^4.0.1"
+
 remove-array-items@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/remove-array-items/-/remove-array-items-1.0.0.tgz#07bf42cb332f4cf6e85ead83b5e4e896d2326b21"
@@ -5283,9 +5378,13 @@ repeat-element@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.2.tgz#ef089a178d1483baae4d93eb98b4f9e4e11d990a"
 
-repeat-string@^1.5.2, repeat-string@^1.6.1:
+repeat-string@^1.5.2, repeat-string@^1.5.4, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
+
+replace-ext@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/replace-ext/-/replace-ext-1.0.0.tgz#de63128373fcbf7c3ccfa4de5a480c45a67958eb"
 
 require-from-string@^1.1.0:
   version "1.2.1"
@@ -5596,6 +5695,10 @@ ssri@^5.2.4:
   resolved "https://registry.yarnpkg.com/ssri/-/ssri-5.3.0.tgz#ba3872c9c6d33a0704a7d71ff045e5ec48999d06"
   dependencies:
     safe-buffer "^5.1.1"
+
+state-toggle@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/state-toggle/-/state-toggle-1.0.1.tgz#c3cb0974f40a6a0f8e905b96789eb41afa1cde3a"
 
 static-extend@^0.1.1:
   version "0.1.2"
@@ -5912,6 +6015,18 @@ trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
 
+trim-trailing-lines@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/trim-trailing-lines/-/trim-trailing-lines-1.1.1.tgz#e0ec0810fd3c3f1730516b45f49083caaf2774d9"
+
+trim@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
+
+trough@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/trough/-/trough-1.0.3.tgz#e29bd1614c6458d44869fc28b255ab7857ef7c24"
+
 tslib@^1.9.0:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
@@ -5974,6 +6089,13 @@ uglifyjs-webpack-plugin@^1.2.4:
     webpack-sources "^1.1.0"
     worker-farm "^1.5.2"
 
+unherit@^1.0.4:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/unherit/-/unherit-1.1.1.tgz#132748da3e88eab767e08fabfbb89c5e9d28628c"
+  dependencies:
+    inherits "^2.0.1"
+    xtend "^4.0.1"
+
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz#2619800c4c825800efdd8343af7dd9933cbe2818"
@@ -5992,6 +6114,17 @@ unicode-match-property-value-ecmascript@^1.0.2:
 unicode-property-aliases-ecmascript@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz#5a533f31b4317ea76f17d807fa0d116546111dd0"
+
+unified@^6.1.2:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/unified/-/unified-6.2.0.tgz#7fbd630f719126d67d40c644b7e3f617035f6dba"
+  dependencies:
+    bail "^1.0.0"
+    extend "^3.0.0"
+    is-plain-obj "^1.1.0"
+    trough "^1.0.0"
+    vfile "^2.0.0"
+    x-is-string "^0.1.0"
 
 union-value@^1.0.0:
   version "1.0.0"
@@ -6027,6 +6160,32 @@ unique-string@^1.0.0:
   resolved "https://registry.yarnpkg.com/unique-string/-/unique-string-1.0.0.tgz#9e1057cca851abb93398f8b33ae187b99caec11a"
   dependencies:
     crypto-random-string "^1.0.0"
+
+unist-util-is@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-is/-/unist-util-is-2.1.2.tgz#1193fa8f2bfbbb82150633f3a8d2eb9a1c1d55db"
+
+unist-util-remove-position@^1.0.0:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-remove-position/-/unist-util-remove-position-1.1.2.tgz#86b5dad104d0bbfbeb1db5f5c92f3570575c12cb"
+  dependencies:
+    unist-util-visit "^1.1.0"
+
+unist-util-stringify-position@^1.0.0, unist-util-stringify-position@^1.1.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/unist-util-stringify-position/-/unist-util-stringify-position-1.1.2.tgz#3f37fcf351279dcbca7480ab5889bb8a832ee1c6"
+
+unist-util-visit-parents@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/unist-util-visit-parents/-/unist-util-visit-parents-2.0.1.tgz#63fffc8929027bee04bfef7d2cce474f71cb6217"
+  dependencies:
+    unist-util-is "^2.1.2"
+
+unist-util-visit@^1.1.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/unist-util-visit/-/unist-util-visit-1.4.0.tgz#1cb763647186dc26f5e1df5db6bd1e48b3cc2fb1"
+  dependencies:
+    unist-util-visit-parents "^2.0.0"
 
 universalify@^0.1.0:
   version "0.1.2"
@@ -6164,6 +6323,25 @@ vary@^1.0.0:
 vendors@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/vendors/-/vendors-1.0.2.tgz#7fcb5eef9f5623b156bcea89ec37d63676f21801"
+
+vfile-location@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/vfile-location/-/vfile-location-2.0.3.tgz#083ba80e50968e8d420be49dd1ea9a992131df77"
+
+vfile-message@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/vfile-message/-/vfile-message-1.0.1.tgz#51a2ccd8a6b97a7980bb34efb9ebde9632e93677"
+  dependencies:
+    unist-util-stringify-position "^1.1.1"
+
+vfile@^2.0.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-2.3.0.tgz#e62d8e72b20e83c324bc6c67278ee272488bf84a"
+  dependencies:
+    is-buffer "^1.1.4"
+    replace-ext "1.0.0"
+    unist-util-stringify-position "^1.0.0"
+    vfile-message "^1.0.0"
 
 vm-browserify@0.0.4:
   version "0.0.4"
@@ -6605,11 +6783,15 @@ ws@^4.0.0:
     async-limiter "~1.0.0"
     safe-buffer "~5.1.0"
 
+x-is-string@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/x-is-string/-/x-is-string-0.1.0.tgz#474b50865af3a49a9c4657f05acd145458f77d82"
+
 xdg-basedir@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-3.0.0.tgz#496b2cc109eca8dbacfe2dc72b603c17c5870ad4"
 
-xtend@^4.0.0, xtend@~4.0.1:
+xtend@^4.0.0, xtend@^4.0.1, xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
 


### PR DESCRIPTION
Hi ! 

Your comment in my last PR made me think: There should be a way to lint js in Markdown.. And here it is ! 

I put `no-undef` for *.md files so we don't have to be perfect JS. I had to add `export default {}` to make it valid tho !

Unfortunately it doesn't support vue :( https://github.com/eslint/eslint-plugin-markdown/issues/82
