### PR TITLE
Set one single root element 

### DIFF
--- a/src/rendering-a-component.md
+++ b/src/rendering-a-component.md
@@ -64,8 +64,10 @@ This can be useful. Imagine you want to test your `App.vue` component, that look
 
 ```vue
 <template>
-  <h1>My Vue App</h1>
-  <fetch-data />
+  <div>
+    <h1>My Vue App</h1>
+    <fetch-data />
+  </div>
 </template>
 ```
 


### PR DESCRIPTION
The provided example throws a compilation error because  there must be one single root element; I know this is just a typo, but this may confuse beginners.