### PR TITLE
SubmitButton component/spec corrections

### DIFF
--- a/demo-app/src/components/SubmitButton.vue
+++ b/demo-app/src/components/SubmitButton.vue
@@ -1,6 +1,6 @@
 <template>
 <div>
-  <span v-if="isAdmin">Admin Privledges</span>
+  <span v-if="isAdmin">Admin Privileges</span>
   <span v-else>Not Authorized</span>
   <button>
     {{ msg }}

--- a/demo-app/tests/unit/SubmitButton.spec.js
+++ b/demo-app/tests/unit/SubmitButton.spec.js
@@ -12,7 +12,7 @@ const factory = (propsData) => {
 }
 
 describe("SubmitButton", () => {
-  describe("does not have admin privledges", ()=> {
+  describe("does not have admin privileges", ()=> {
     it("renders a message", () => {
       const wrapper = factory()
 
@@ -21,11 +21,11 @@ describe("SubmitButton", () => {
     })
   })
 
-  describe("has admin privledges", ()=> {
+  describe("has admin privileges", ()=> {
     it("renders a message", () => {
       const wrapper = factory({ isAdmin: true })
 
-      expect(wrapper.find("span").text()).toBe("Admin Privledges")
+      expect(wrapper.find("span").text()).toBe("Admin Privileges")
       expect(wrapper.find("button").text()).toBe("submit")
     })
   })

--- a/demo-app/tests/unit/SubmitButton.spec.js
+++ b/demo-app/tests/unit/SubmitButton.spec.js
@@ -12,7 +12,7 @@ const factory = (propsData) => {
 }
 
 describe("SubmitButton", () => {
-  describe("has admin privledges", ()=> {
+  describe("does not have admin privledges", ()=> {
     it("renders a message", () => {
       const wrapper = factory()
 
@@ -21,7 +21,7 @@ describe("SubmitButton", () => {
     })
   })
 
-  describe("does not have admin privledges", ()=> {
+  describe("has admin privledges", ()=> {
     it("renders a message", () => {
       const wrapper = factory({ isAdmin: true })
 


### PR DESCRIPTION
Corrected "privilege" spellings.
Swapped describe block descriptions; they were backwards.