### PR TITLE
Sidebar image bug

### DIFF
--- a/src/.vuepress/theme/components/Sidebar.vue
+++ b/src/.vuepress/theme/components/Sidebar.vue
@@ -4,15 +4,16 @@
       <CarbonAds />
     -->
     <a href="https://vuejs-course.com/" target="_blank">
-      <img 
-        id="ad" 
-        :src="$withBase('vuejs-course.png')" 
+      <img
+        id="ad"
+        :src="'/vuejs-course.png'"
+        alt='vuejs-course banner'
       />
     </a>
     <br />
     <div class="info">
       <small>
-      Hi! Please check out my 
+      Hi! Please check out my
       <a href="https://vuejs-course.com/" target="_blank">upcoming</a>
       <a href="https://vuejs-course.com/" target="_blank">course</a>
       <a href="https://vuejs-course.com/" target="_blank">on</a>
@@ -24,31 +25,31 @@
 
     <!-- https://vuejs-course.com/ -->
 
-    <!-- 
+    <!--
 
     <VueSchool />
 
-    <div 
+    <div
       class="info"
     >
-      Prefer videos? I recommend Vue School's 
+      Prefer videos? I recommend Vue School's
 
-      <a 
+      <a
         href="https://vueschool.io/courses/learn-how-to-test-vuejs-components?friend=vth"
-        target="_blank" 
+        target="_blank"
         @click="track"
     
         >
           Testing Vue.js
-        </a> 
+        </a>
 
-        <a 
-          target="_blank" 
+        <a
+          target="_blank"
           href="https://vueschool.io/courses/learn-how-to-test-vuejs-components?friend=vth"
           @click="track"
         >
           Components course
-        </a> 
+        </a>
 
         to learn vue-test-utils, Jest and the other tooling with guys who literally built Vue.js.
     </div>


### PR DESCRIPTION
## Steps to reproduce

Open the [book](https://lmiller1990.github.io/vue-testing-handbook/ru/) and hit F5 (refresh the page).

## Expected behaviour
Vue.js course image is visible

## Actual behaviour
Vue.js course image is not visible

The path should be equal to `https://lmiller1990.github.io/vue-testing-handbook/vuejs-course.png`
but the actual path is equal to `https://lmiller1990.github.io/vue-testing-handbook/ru/vuejs-course.png`

I found a solution. Just change `$withBase` to `/`.