### PR TITLE
Add more context in computed properties

### DIFF
--- a/src/computed-properties.md
+++ b/src/computed-properties.md
@@ -123,7 +123,7 @@ Now `yarn test:unit` passes!
 
 ## Testing with `call` 
 
-The `call` method is vanilla javascript used to call a function and pass to it an argument that will set `this` for that function. Seeing as computed is a function we can use that in the tests. In the `props` we set the value of `even` and in turn this becomes available to the component as `this.even`. So by using call we can override this and set `even` to what we want to test. So now using `call` we will add a test for the case of `even: false`. This time, we will see an alternative way to test a computed property, without actually rendering the component.
+The `call` method is vanilla JavaScript used to call a function and pass to it an argument that will set `this` for that function. Seeing as computed is a function we can use that in the tests. In the `props` we set the value of `even` and in turn this becomes available to the component as `this.even`. So by using call we can override this and set `even` to what we want to test. So now using `call` we will add a test for the case of `even: false`. This time, we will see an alternative way to test a computed property, without actually rendering the component.
 
 The test, first:
 

--- a/src/computed-properties.md
+++ b/src/computed-properties.md
@@ -123,7 +123,7 @@ Now `yarn test:unit` passes!
 
 ## Testing with `call` 
 
-We will now add a test for the case of `even: false`. This time, we will see an alternative way to test a computed property, without actually rendering the component.
+The `call` method is vanilla javascript used to call a function and pass to it an argument that will set `this` for that function. Seeing as computed is a function we can use that in the tests. In the `props` we set the value of `even` and in turn this becomes available to the component as `this.even`. So by using call we can override this and set `even` to what we want to test. So now using `call` we will add a test for the case of `even: false`. This time, we will see an alternative way to test a computed property, without actually rendering the component.
 
 The test, first:
 


### PR DESCRIPTION
Add some more context of what `call` is and how it works. I thought it was part of vue-test-utils but saw it's actually vanilla JS. So this is for more people like me that might be confused.