### PR TITLE
Demo app vue 3 -  Parent visible

### DIFF
--- a/demo-app-vue-3/tests/unit/Parent.spec.js
+++ b/demo-app-vue-3/tests/unit/Parent.spec.js
@@ -8,7 +8,7 @@ describe("Parent", () => {
   it("does not render a span", () => {
     const wrapper = mount(Parent)
 
-    expect(wrapper.find("span").element).not.toBeVisible()
+    expect(wrapper.find("span").isVisible()).toBe(false)
   })
 
   it("does render a span", () => {
@@ -18,7 +18,7 @@ describe("Parent", () => {
       }
     })
 
-    expect(wrapper.find("span").element).toBeVisible()
+    expect(wrapper.find("span").isVisible()).toBe(true)
   })
 
   it("does not render a Child component", () => {

--- a/src/computed-properties.md
+++ b/src/computed-properties.md
@@ -123,7 +123,7 @@ Now `yarn test:unit` passes!
 
 ## Testing with `call` 
 
-We will now add a test for the case of `even: false`. This time, we will see an alternative way to test a computed property, without actually rendering the component.
+The `call` method is vanilla javascript used to call a function and pass to it an argument that will set `this` for that function. Seeing as computed is a function we can use that in the tests. In the `props` we set the value of `even` and in turn this becomes available to the component as `this.even`. So by using call we can override this and set `even` to what we want to test. So now using `call` we will add a test for the case of `even: false`. This time, we will see an alternative way to test a computed property, without actually rendering the component.
 
 The test, first:
 


### PR DESCRIPTION
This test was failing even though the span was actually show. According to [the docs](https://next.vue-test-utils.vuejs.org/api/#isvisible) there is actually a `isVisible` api method. I made the change and the test passed.