### PR TITLE
Add jest.config to initial setup

### DIFF
--- a/src/mocking-global-objects.md
+++ b/src/mocking-global-objects.md
@@ -128,6 +128,15 @@ The test passes, and the following markup is rendered:
 </div>
 ```
 
+Note: if the test is still failing, it's likely because `jest.init.js` is not set to load before the tests run.  Ensure that your `jest.config.js` file includes the following:
+
+```js
+module.exports = {
+  setupFiles: ["<rootDir>/jest.init.js"]
+}
+```
+and then re-run the test.
+
 You can read about using `mocks` to test Vuex [here](https://lmiller1990.github.io/vue-testing-handbook/vuex-in-components.html#using-a-mock-store). The technique is the same.
 
 ## Conclusion

--- a/src/setting-up-for-tdd.md
+++ b/src/setting-up-for-tdd.md
@@ -35,6 +35,37 @@ Time:        2.074s
 
 Congratulations, you just ran your first passing test!
 
+
+## Modify your Jest config file
+
+To ensure your local configuration matches the one used in this book, you should override your current `jest.config.js` file with the following:
+
+```js
+module.exports = {
+  moduleFileExtensions: [
+    'js',
+    'jsx',
+    'json',
+    'vue'
+  ],
+  transform: {
+    '^.+\\.vue$': 'vue-jest',
+    '.+\\.(css|styl|less|sass|scss|png|jpg|ttf|woff|woff2)$': 'jest-transform-stub',
+    '^.+\\.jsx?$': 'babel-jest'
+  },
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1'
+  },
+  snapshotSerializers: [
+    'jest-serializer-vue'
+  ],
+  testMatch: [
+    '<rootDir>/tests/unit/**/*.spec.(js|jsx|ts|tsx)|**/__tests__/*.(js|jsx|ts|tsx)'
+  ],
+  setupFiles: ["<rootDir>/jest.init.js"]
+}
+```
+
 ## Writing your first test
 
 We ran an existing test that came with the project. Let's get our hands dirty, writing our own component, and a test. Traditionally when doing TDD, you write the failing test first, then implement the code which allows the test to pass. For now, we will write the component first.


### PR DESCRIPTION
In the chapter `mocking-global-objects.md`, it's suggested to add the mock for the i18n library to the `jest.init.js` file, since this file "is loaded before the tests are run automatically." But this needs to be expressly configured in the `jest.config.js` file.

This PR suggests 2 additions to `vue-testing-handbook`:

1. Add the suggested configuration for `jest.config.js` to `setting-up-for-tdd.md`
2. Add a suggestion to verify `jest.config.js` if the test in  `mocking-global-objects.md` is failing.